### PR TITLE
Updating minSdkVersion from 7 to 9

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -35,7 +35,7 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 9
         targetSdkVersion 25
     }
 


### PR DESCRIPTION
Android Support Library 25 is used in project and that version needs minSdkVersion set to 9