### PR TITLE
GenericAccountService: throw UnsupportedOperationException

### DIFF
--- a/Application/src/main/java/com/example/android/common/accounts/GenericAccountService.java
+++ b/Application/src/main/java/com/example/android/common/accounts/GenericAccountService.java
@@ -87,14 +87,14 @@ public class GenericAccountService extends Service {
         public Bundle addAccount(AccountAuthenticatorResponse accountAuthenticatorResponse,
                                  String s, String s2, String[] strings, Bundle bundle)
                 throws NetworkErrorException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Bundle confirmCredentials(AccountAuthenticatorResponse accountAuthenticatorResponse,
                                          Account account, Bundle bundle)
                 throws NetworkErrorException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
We have to throw UnsupportedOperationException instead of returning null, otherwise the caller will be stuck waiting forever.

E.g.: Currently, if you go to System Settings -> Account -> Add account -> BasicSyncAdapter, if get an irresponsible blank screen.
Throwing an error instead, the operation is just ignored and the UI continues responsible.